### PR TITLE
Restrict country and extends options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,3 +126,21 @@ The underlying `ul` and `li` are not accessible via slots but you can style them
     </span>
 </google-places-autocomplete>
 ```
+
+### Restrict Country and more options
+Support restrict country and extends options
+
+Follow this document for getting more details
+
+[https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest)
+
+```html
+<template>
+  <div>
+    <google-places-autocomplete
+      :country="['us', 'au']"
+      :options="{ types: ['(cities)'] }"
+    />
+  </div>
+</template>
+```

--- a/src/GooglePlacesAutocomplete.vue
+++ b/src/GooglePlacesAutocomplete.vue
@@ -82,7 +82,14 @@ export default {
             required: false,
             default: () => ({}),
         },
-
+        country: {
+            type: [Array, String],
+            required: false,
+        },
+        options: {
+            type: Object,
+            default: () => ({}),
+        },
     },
 
     computed: {
@@ -101,8 +108,20 @@ export default {
                 'geometry',
                 ...this.fields,
             ]
-        }
+        },
 
+        mapOptions() {
+            const options = Object.assign({}, this.options);
+
+            if (this.country) {
+                Object.assign(options, {
+                    componentRestrictions: {
+                        country: this.country,
+                    },
+                })
+            }
+            return options
+        }
     },
 
     watch: {
@@ -212,6 +231,7 @@ export default {
                 input,
                 sessionToken,
                 bounds,
+                ...this.mapOptions,
             }, (predictions, status) => {
                 this.$set(this.autocomplete, 'status', status)
 


### PR DESCRIPTION
* Support restrict country
* Extends options

we can replace more options, follow this document to get more details.

https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest
